### PR TITLE
Replaced #mc_embed_signup with #mc_signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
 
 		<section class="survey">
 		<!-- Begin MailChimp Signup Form -->
-		<div id="mc_embed_signup">
+		<div id="mc_signup">
 			<form action="http://skinnywhitegirl.us2.list-manage1.com/subscribe/post?u=493c3cbc6ea8f074d84037bef&amp;id=eb4baf5487" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
 				<h2>Newsletter &amp; Fit Survey</h2>
 				<p class="helper">I respect that this data is very personal. It will never be sold to anyone. Period.</p>
@@ -227,7 +227,7 @@
 		try{
 		    err_style = mc_custom_error_style;
 		} catch(e){
-		    err_style = '#mc_embed_signup input.mce_inline_error{border-color:#6B0505;} #mc_embed_signup div.mce_inline_error{margin: 0 0 1em 0; padding: 5px 10px; background-color:#6B0505; font-weight: bold; z-index: 1; color:#fff;}';
+		    err_style = '#mc_signup input.mce_inline_error{border-color:#6B0505;} #mc_signup div.mce_inline_error{margin: 0 0 1em 0; padding: 5px 10px; background-color:#6B0505; font-weight: bold; z-index: 1; color:#fff;}';
 		}
 		var head= document.getElementsByTagName('head')[0];
 		var style= document.createElement('style');
@@ -270,7 +270,7 @@
 		      options = { url: 'http://skinnywhitegirl.us2.list-manage.com/subscribe/post-json?u=493c3cbc6ea8f074d84037bef&id=eb4baf5487&c=?', type: 'GET', dataType: 'json', contentType: "application/json; charset=utf-8",
 		                    beforeSubmit: function(){
 		                        $('#mce_tmp_error_msg').remove();
-		                        $('.datefield','#mc_embed_signup').each(
+		                        $('.datefield','#mc_signup').each(
 		                            function(){
 		                                var txt = 'filled';
 		                                var fields = new Array();
@@ -300,7 +300,7 @@
 			                                    }
 		                                    });
 		                            });
-		                        $('.phonefield-us','#mc_embed_signup').each(
+		                        $('.phonefield-us','#mc_signup').each(
 		                            function(){
 		                                var fields = new Array();
 		                                var i = 0;
@@ -365,7 +365,7 @@
 		                err_id = 'mce_tmp_error_msg';
 		                html = '<div id="'+err_id+'" style="'+err_style+'"> '+msg+'</div>';
 		                
-		                var input_id = '#mc_embed_signup';
+		                var input_id = '#mc_signup';
 		                var f = $(input_id);
 		                if (ftypes[index]=='address'){
 		                    input_id = '#mce-'+fnames[index]+'-addr1';
@@ -393,6 +393,6 @@
 		}
 		
 		</script>
-		<!--End mc_embed_signup-->
+		<!--End mc_signup-->
 	</body>
 </html>


### PR DESCRIPTION
Was checking out crystalbeasley.com with Elena and was trying to hunt down the signup form.  When I couldn't find it, I realized it was getting blocked by my adblock filters.  Specifically, the offending filter was the https://www.fanboy.co.nz Annoyances Filter list which blocks the #mc_embed_signup id tag.  It is a decently common filter list that can be added easily by adblock users from the main adblock options window so I figured I would bring it to your attention if you have anyone else finding themselves in a similar situation.

I sent a PR with some code that simply changes that ID tag to something slightly different defeating the filter, but the form was a bit more complicated than I anticipated so I can't verify if it broke anything.  It did defeat the filter though!  If you are interested in the fix, I would test the form before merging.
